### PR TITLE
Fix typo

### DIFF
--- a/src/lang/para.cpp
+++ b/src/lang/para.cpp
@@ -236,7 +236,7 @@ static bool parseOption(int argc,char *argv[]) {
 	namespace bstPrgOpt=boost::program_options;
 	bstPrgOpt::options_description desc("options");
 	desc.add_options()
-		("help,h",		"pint help.")
+		("help,h",		"print help.")
 		("version,v",	"print version info.")
 		("quiet,q",		"quiet mode (equivalent to -nk).")
 		("thread",bstPrgOpt::value<int>(),"set maximum thread (ex: --thread 8).")


### PR DESCRIPTION
コマンドライン引数で不正なオプションを指定した場合に表示されるテキストで脱字を発見したので、修正しました。

修正前の挙動：

```bash
$ ./para --xxx            
unrecognised option '--xxx'
options:
  -h [ --help ]              pint help.
  -v [ --version ]           print version info.
  -q [ --quiet ]             quiet mode (equivalent to -nk).
  --thread arg               set maximum thread (ex: --thread 8).
  -e [ --eval ] arg          eval parameter.
  -E [ --eval-and-exit ] arg eval and exit (for one liner).
  -n [ --noprompt ]          suppress prompt.
  -k [ --nook ]              suppress 'ok'.
  -t [ --time ]              display spent time.
```

修正後の挙動：

```bash
$ ./para --xxx
unrecognised option '--xxx'
options:
  -h [ --help ]              print help.
  -v [ --version ]           print version info.
  -q [ --quiet ]             quiet mode (equivalent to -nk).
  --thread arg               set maximum thread (ex: --thread 8).
  -e [ --eval ] arg          eval parameter.
  -E [ --eval-and-exit ] arg eval and exit (for one liner).
  -n [ --noprompt ]          suppress prompt.
  -k [ --nook ]              suppress 'ok'.
  -t [ --time ]              display spent time.
```