### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/ext
+/src/obj
+/libPP.so
+/para


### PR DESCRIPTION
git で管理する必要のないファイル/ディレクトリを `/.gitignore` に列挙しました。
このファイルを設置しておくことで、指定されているファイル/ディレクトリに変更があっても git は差分を検知しなくなります。

具体的には

- `/ext`, `/src/obj` ディレクトリ
- `/libPP.so`
- `/para`

は git で管理する必要がないと思われるため、`.gitignore` に追記しています。