### PR TITLE
オプション v または h をつけて実行された場合の exit code を 0 に修正した

### DIFF
--- a/src/lang/para.cpp
+++ b/src/lang/para.cpp
@@ -258,7 +258,7 @@ static bool parseOption(int argc,char *argv[]) {
 		for(auto const& str
 		  : bstPrgOpt::collect_unrecognized(parseResult.options,
 											bstPrgOpt::include_positional)) {
-			argVec.push_back(str);	
+			argVec.push_back(str);
 		}
 	} catch(const bstPrgOpt::error& e) {
 		std::cerr << e.what() << '\n';


### PR DESCRIPTION
Fixes #6 

加えて `parseOption` 関数の挙動も修正し、「パース処理に成功したかどうか」ではなく「パース完了後に何をすればいいか」を表す値を返すようにしました。そもそもパース処理に失敗した場合は即座に異常終了するようにしてあります。

このようにリファクタリングしたのは、パース完了後の処理 (`printUsage` や `printVersion` 関数の呼び出し) を `parseOption` 関数内で行うのは、関数名からは想像できないことも余計にやっていて不自然だったからです。